### PR TITLE
Uncap Cabal release dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cabal: ["3.2.0.0", "3.4.0.0", "3.10.1.0"]
-        ghc: ["8.6.5", "8.8.3", "8.10.5", "9.0.1", "9.6.2"]
+        cabal: ["3.4.0.0", "3.8.1.0", "3.10.1.0"]
+        ghc: ["9.0.2", "9.2.8", "9.4.7", "9.6.2"]
         os: [ubuntu-latest, macOS-latest]
 
     steps:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,7 @@ module Main (main) where
 import Control.Monad (unless, when)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-#if !MIN_VERSION_Cabal(3,10,0)
+#if !MIN_VERSION_Cabal(3,6,0)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 #else
 import Distribution.Simple.PackageDescription (readGenericPackageDescription)

--- a/uusi.cabal
+++ b/uusi.cabal
@@ -34,7 +34,7 @@ source-repository head
 common common-options
   build-depends:
     , base   >=4.8 && <5
-    , Cabal  ^>=3.2 || ^>=3.4 || ^>=3.10
+    , Cabal  ^>=3.2 || ^>=3.4 || ==3.6.3 || >=3.8
     , text
 
   ghc-options:

--- a/uusi.cabal
+++ b/uusi.cabal
@@ -34,7 +34,7 @@ source-repository head
 common common-options
   build-depends:
     , base   >=4.8 && <5
-    , Cabal  ^>=3.2 || ^>=3.4 || ==3.6.3 || >=3.8
+    , Cabal  ^>=3.2 || ^>=3.4 || ==3.6.3 || ^>= 3.8 || ^>= 3.10
     , text
 
   ghc-options:


### PR DESCRIPTION
A change in Cabal 3.6.3 (contained in GHC 9.2.8) makes that version the only allowed release in that series.
Otherwise uncap the dependency on Cabal, so future compiler releases (like 9.8) don't require unnecessary version bumps.